### PR TITLE
WIP: Add #[Factory] attribute - Option 1 via tag and YamlFileLoader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -61,6 +61,7 @@ use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
 use Symfony\Component\DependencyInjection\EnvVarLoaderInterface;
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 use Symfony\Component\DependencyInjection\Exception\AutoconfigureFailedException;
@@ -188,6 +189,7 @@ use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Symfony\Component\Workflow;
 use Symfony\Component\Workflow\WorkflowInterface;
 use Symfony\Component\Yaml\Command\LintCommand as BaseYamlLintCommand;
+use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\CallbackInterface;
@@ -675,22 +677,32 @@ class FrameworkExtension extends Extension
                 $tagAttributes['method'] = $reflector->getName();
                 $tagAttributes['class'] = $reflector->getDeclaringClass()->name;
                 $reflector = $reflector->getDeclaringClass();
-            }
-            if (null === $tagAttributes['class'] && null === $tagAttributes['service'] && null === $tagAttributes['expression']) {
-                throw new LogicException(sprintf('Factory attribute must declare a class, service or expression in %s.', $reflector->name));
-            }
-            if (null === $tagAttributes['method'] && (null !== $tagAttributes['class'] || null !== $tagAttributes['service'])) {
-                $tagAttributes['method'] = '__invoke';
+            } else {
+                if (null === $tagAttributes['class'] && null === $tagAttributes['service'] && null === $tagAttributes['expression']) {
+                    $tagAttributes['class'] = $reflector->getName();
+                }
+                if (null === $tagAttributes['method'] && (null !== $tagAttributes['class'] || null !== $tagAttributes['service'])) {
+                    $tagAttributes['method'] = '__invoke';
+                }
             }
             // Prevent using both #[Factory] and #[Autoconfigure(constructor:...)]
             $autoconfigureWithConstructor = array_filter(
                 $reflector->getAttributes(Autoconfigure::class, \ReflectionAttribute::IS_INSTANCEOF),
                 static fn(\ReflectionAttribute $attr) => null !== $attr->newInstance()->constructor
             );
-            if (0 < \count($autoconfigureWithConstructor)) {
+            if (0 !== \count($autoconfigureWithConstructor)) {
                 throw new AutoconfigureFailedException($reflector->name, sprintf('Using both attributes #[Factory] and #[Autoconfigure(constructor: ...)] on is not allowed in %s.', $reflector->name));
             }
-            $tagAttributes['arguments'] = array_map(fn ($argument): string => $argument instanceof Reference ? ('@'.$argument) : $argument, $tagAttributes['arguments']);
+            // We have to use internals from YamlDumper to dump arguments to string
+            $yamlDumperReflector = new \ReflectionClass(YamlDumper::class);
+            $yamlDumper = $yamlDumperReflector->newInstanceWithoutConstructor();
+            $dumpValue = $yamlDumperReflector->getMethod('dumpValue');
+            $rawYamlDumper = new Dumper();
+            $tagAttributes['arguments'] = array_map(
+                static fn ($argument) =>  $rawYamlDumper->dump($dumpValue->invoke($yamlDumper, $argument)),
+                $tagAttributes['arguments'] ?? []
+            );
+
             $definition->addTag('container.from_factory', $tagAttributes);
         });
         $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {

--- a/src/Symfony/Component/DependencyInjection/Attribute/Factory.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Factory.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to define the factory for a base type.
+ *
+ * @author Maelan Le Borgne <maelan.leborgne@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS|\Attribute::TARGET_METHOD)]
+class Factory
+{
+    public function __construct(
+        public ?string $class = null,
+        public ?string $service = null,
+        public ?string $method = null,
+        public ?string $expression = null,
+        public array $arguments = [],
+    )
+    {
+        if ((null !== $this->class && null !== $this->service) ||
+            (null !== $this->class && null !== $this->expression) ||
+            (null !== $this->service && null !== $this->expression)) {
+            throw new \LogicException('The #[Factory] attribute must declare only one of "$expression", "$class" or "$service".');
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/Factory.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Factory.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Attribute;
 
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
 /**
  * An attribute to define the factory for a base type.
  *
@@ -27,10 +29,16 @@ class Factory
         public array $arguments = [],
     )
     {
-        if ((null !== $this->class && null !== $this->service) ||
-            (null !== $this->class && null !== $this->expression) ||
-            (null !== $this->service && null !== $this->expression)) {
-            throw new \LogicException('The #[Factory] attribute must declare only one of "$expression", "$class" or "$service".');
+        if (!$this->assertOneOrNoneOf($this->class, $this->service, $this->expression)) {
+            throw new LogicException('The #[Factory] attribute must declare one or none of "$expression", "$class" or "$service".');
         }
+        if (isset($this->method) && isset($this->expression)) {
+            throw new LogicException('The #[Factory] attribute cannot declare both "$method" and "$expression".');
+        }
+    }
+
+    private function assertOneOrNoneOf(...$arguments): string
+    {
+        return 1 >= \count(array_filter($arguments, fn ($argument) => null !== $argument));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/Factory.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Factory.php
@@ -39,6 +39,6 @@ class Factory
 
     private function assertOneOrNoneOf(...$arguments): string
     {
-        return 1 >= \count(array_filter($arguments, fn ($argument) => null !== $argument));
+        return \count(array_filter($arguments, fn ($argument) => null !== $argument)) <= 1;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -46,6 +46,7 @@ class PassConfig
                 new AutowireAsDecoratorPass(),
                 new AttributeAutoconfigurationPass(),
                 new ResolveInstanceofConditionalsPass(),
+                new RegisterFactoryPass(),
                 new RegisterEnvVarProcessorsPass(),
             ],
             -1000 => [new ExtensionCompilerPass()],

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterFactoryPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterFactoryPass.php
@@ -11,137 +11,98 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Exception\AutoconfigureFailedException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
- * Register factories for services tagged with "container.factory".
+ * Register factories for services tagged with "container.from_factory".
  *
  * @author Maelan Le Borgne <maelan.leborgne@gmail.com>
  */
 final class RegisterFactoryPass implements CompilerPassInterface
 {
-    private static \Closure $registerForAutoconfiguration;
+    private static \Closure $registerFactoryConfigurationClosure;
 
     public function process(ContainerBuilder $container): void
     {
-        foreach ($container->findTaggedServiceIds('container.factory') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('container.from_factory') as $id => $arguments) {
+            $tagArguments = $arguments[0];
             $definition = $container->getDefinition($id);
-            if (!$definition->hasTag('container.ignore_attributes')) {
-                $this->processDefinitionOption1($container, $definition, $attributes[0]);
+            $class = $container->getReflectionClass($definition->getClass(), false);
+            if (null === $class) {
+                return;
             }
+
+            $factory = $this->resolveFactory($tagArguments, $class);
+
+            if (!isset(self::$registerFactoryConfigurationClosure)) {
+                /** @var YamlFileLoader $yamlLoader */
+                $reflectionClass = new \ReflectionClass(YamlFileLoader::class);
+                $yamlLoader = $reflectionClass->newInstanceWithoutConstructor();
+                $parseDefinition = $reflectionClass->getMethod('parseDefinition');
+
+                self::$registerFactoryConfigurationClosure = static function (ContainerBuilder $container, string $id, string $fileName, array|string $factory, array $arguments) use ($parseDefinition, $yamlLoader) {
+                    $parseDefinition->invoke(
+                        $yamlLoader,
+                        $id,
+                        [$container->getDefinition($id)] + ['factory' => $factory, 'arguments' => $arguments],
+                        $fileName,
+                        [],
+                        false,
+                        false
+                    );
+                };
+            }
+
+            (self::$registerFactoryConfigurationClosure)($container, $id, $class->getFileName(), $factory, $tagArguments['arguments'] ?? []);
         }
     }
 
-    // Option 1 : Register the factory directly on the definition.
-    // May require more work to maintain because it duplicates part of the factory setting done in the file loaders
-    private function processDefinitionOption1(ContainerBuilder $container, Definition $definition, array $attributes): void
+    /**
+     * Validate the tag arguments and transform them into a factory configuration that can be used by the YamlFileLoader.
+     *
+     * @param array{class?: string, service?: string, method?: string, expression?: string, arguments?: array} $tagArguments
+     */
+    private function resolveFactory(array $tagArguments, \ReflectionClass $class): array|string
     {
-        $class = $container->getReflectionClass($definition->getClass(), false);
-        if (null === $class) {
-            return;
+        $tagArguments = [
+            'class' => $tagArguments['class'] ?? null,
+            'service' => $tagArguments['service'] ?? null,
+            'expression' => $tagArguments['expression'] ?? null,
+            'method' => $tagArguments['method'] ?? null,
+        ];
+        // When using expression, no method can be set
+        if (is_string($tagArguments['method']) && is_string($tagArguments['expression'])) {
+            throw new LogicException('The "container.from_factory" tag cannot declare both "method" and "expression".');
         }
-        // Prevent conflict with #[Autoconfigure(constructor: ...)]
-        $autoconfigureWithConstructor = array_filter(
-            $class->getAttributes(Autoconfigure::class, \ReflectionAttribute::IS_INSTANCEOF),
-            static fn(\ReflectionAttribute $attribute) => null !== $attribute->newInstance()->constructor
-        );
-        if (0 < \count($autoconfigureWithConstructor)) {
-            throw new AutoconfigureFailedException($class->name, sprintf('Using both attributes #[Factory] and #[Autoconfigure(constructor: ...)] on is not allowed in %s.', $class->getName()));
+        // A method is set but no service nor class : resolve to "class::method"
+        if (is_string($tagArguments['method']) && (!is_string($tagArguments['class']) && !is_string($tagArguments['service']))) {
+            $tagArguments['class'] = $class->name;
+        }
+        // No method is set but a service is set : resolve to "service::__invoke"
+        $method = !is_string($tagArguments['method']) && is_string($tagArguments['service']) ? '__invoke' : $tagArguments['method'];
+        unset($tagArguments['method']);
+        // Only one of expression, class or service can be set
+        if (1 !== \count(\array_filter($tagArguments, static fn ($argument) => is_string($argument)))) {
+            throw new LogicException('The "container.from_factory" tag must declare one of "expression", "class" or "service".');
         }
 
-        $factory = $this->resolveFactoryForOption1($attributes, $class);
-        if (\is_array($factory)) {
-            if (null === $factory[0] && !is_callable([$class->name, $factory[1]]) || is_string($factory[0]) && !is_callable($factory)) {
-                throw new \InvalidArgumentException(sprintf('Invalid factory method "%s" on service "%s": method does not exist or is not static.', $factory[1], $definition->getClass()));
-            }
-        }
-
-        $definition->setFactory($factory)
-            ->setArguments($attributes['arguments'] ?? []);
-    }
-
-    private function resolveFactoryForOption1(array $attributes, \ReflectionClass $class): array|string
-    {
-        if (is_string($attributes['expression'] ?? null)) {
+        if (is_string($tagArguments['expression'])) {
             if (!class_exists(Expression::class)) {
-                throw new \LogicException(sprintf('The "container.factory" tag on %s cannot declare an "expression" when the ExpressionLanguage component is not available.', $class->name));
+                throw new LogicException(sprintf('Using an expression as factory for %s requires the ExpressionLanguage component. Try running "composer require symfony/expression-language".', $class->name));
             }
 
-            return '@=' . $attributes['expression'];
+            return str_starts_with($tagArguments['expression'], '@=') ? $tagArguments['expression'] : ('@=' . $tagArguments['expression']);
+        } elseif (is_string($tagArguments['service'])) {
+            $firstElement = str_starts_with($tagArguments['service'], '@') ? $tagArguments['service'] : ('@' . $tagArguments['service']);
+        } elseif (is_string($tagArguments['class'])) {
+            $firstElement = $tagArguments['class'];
+        } else {
+            throw new LogicException('The "container.from_factory" tag must declare a "service", "class" or "expression".');
         }
 
-        $serviceReference = is_string($attributes['service'] ?? null) ? new Reference($attributes['service']) : null;
-
-        return [$attributes['class'] ?? $serviceReference, $attributes['method'] ?? '__invoke'];
-    }
-
-    // Option 2 : Rely on YamlFileLoader to register the factory like in RegisterAutoconfigureAttributesPass.
-    // Requires to add 'factory' and 'arguments' to the YamlFileLoader::INSTANCEOF_KEYWORDS const.
-    private function processDefinitionOption2(ContainerBuilder $container, Definition $definition, array $attributes): void
-    {
-        $class = $container->getReflectionClass($definition->getClass(), false);
-        if (null === $class) {
-            return;
-        }
-        // Prevent conflict with #[Autoconfigure(constructor: ...)]
-        $autoconfigureWithConstructor = array_filter(
-            $class->getAttributes(Autoconfigure::class, \ReflectionAttribute::IS_INSTANCEOF),
-            static fn(\ReflectionAttribute $attribute) => null !== $attribute->newInstance()->constructor
-        );
-        if (0 < \count($autoconfigureWithConstructor)) {
-            throw new AutoconfigureFailedException($class->name, sprintf('Using both attributes #[Factory] and #[Autoconfigure(constructor: ...)] on is not allowed in %s.', $class->getName()));
-        }
-
-        $factory = $this->resolveFactoryForOption2($attributes, $class);
-
-        if (isset(self::$registerForAutoconfiguration)) {
-            (self::$registerForAutoconfiguration)($container, $class, $factory, $attributes['arguments'] ?? []);
-
-            return;
-        }
-
-        $parseDefinitions = new \ReflectionMethod(YamlFileLoader::class, 'parseDefinitions');
-        $yamlLoader = $parseDefinitions->getDeclaringClass()->newInstanceWithoutConstructor();
-
-        self::$registerForAutoconfiguration = static function (ContainerBuilder $container, \ReflectionClass $class, array $factory, array $arguments) use ($parseDefinitions, $yamlLoader) {
-            $config = ['factory' => $factory, 'arguments' => $arguments];
-
-            $parseDefinitions->invoke(
-                $yamlLoader,
-                [
-                    'services' => [
-                        '_instanceof' => [
-                            $class->name => [$container->getDefinition($class->name)] + $config,
-                        ],
-                    ],
-                ],
-                $class->getFileName(),
-                false
-            );
-        };
-
-        (self::$registerForAutoconfiguration)($container, $class, $factory, $attributes['arguments'] ?? []);
-    }
-
-    private function resolveFactoryForOption2(array $attributes, \ReflectionClass $class): array|string
-    {
-        if (is_string($attributes['expression'] ?? null)) {
-            if (!class_exists(Expression::class)) {
-                throw new \LogicException(sprintf('The "container.factory" tag on %s cannot declare an "expression" when the ExpressionLanguage component is not available.', $class->name));
-            }
-
-            return '@=' . $attributes['expression'];
-        }
-
-        $method = $attributes['method'] ?? '__invoke';
-        $service = is_string($attributes['service'] ?? null) ? '@' . $attributes['service'] : null;
-
-        return [$attributes['class'] ?? $service, $method];
+        return [$firstElement, $method];
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterFactoryPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterFactoryPass.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\AutoconfigureFailedException;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+/**
+ * Register factories for services tagged with "container.factory".
+ *
+ * @author Maelan Le Borgne <maelan.leborgne@gmail.com>
+ */
+final class RegisterFactoryPass implements CompilerPassInterface
+{
+    private static \Closure $registerForAutoconfiguration;
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('container.factory') as $id => $attributes) {
+            $definition = $container->getDefinition($id);
+            if (!$definition->hasTag('container.ignore_attributes')) {
+                $this->processDefinitionOption1($container, $definition, $attributes[0]);
+            }
+        }
+    }
+
+    // Option 1 : Register the factory directly on the definition.
+    // May require more work to maintain because it duplicates part of the factory setting done in the file loaders
+    private function processDefinitionOption1(ContainerBuilder $container, Definition $definition, array $attributes): void
+    {
+        $class = $container->getReflectionClass($definition->getClass(), false);
+        if (null === $class) {
+            return;
+        }
+        // Prevent conflict with #[Autoconfigure(constructor: ...)]
+        $autoconfigureWithConstructor = array_filter(
+            $class->getAttributes(Autoconfigure::class, \ReflectionAttribute::IS_INSTANCEOF),
+            static fn(\ReflectionAttribute $attribute) => null !== $attribute->newInstance()->constructor
+        );
+        if (0 < \count($autoconfigureWithConstructor)) {
+            throw new AutoconfigureFailedException($class->name, sprintf('Using both attributes #[Factory] and #[Autoconfigure(constructor: ...)] on is not allowed in %s.', $class->getName()));
+        }
+
+        $factory = $this->resolveFactoryForOption1($attributes, $class);
+        if (\is_array($factory)) {
+            if (null === $factory[0] && !is_callable([$class->name, $factory[1]]) || is_string($factory[0]) && !is_callable($factory)) {
+                throw new \InvalidArgumentException(sprintf('Invalid factory method "%s" on service "%s": method does not exist or is not static.', $factory[1], $definition->getClass()));
+            }
+        }
+
+        $definition->setFactory($factory)
+            ->setArguments($attributes['arguments'] ?? []);
+    }
+
+    private function resolveFactoryForOption1(array $attributes, \ReflectionClass $class): array|string
+    {
+        if (is_string($attributes['expression'] ?? null)) {
+            if (!class_exists(Expression::class)) {
+                throw new \LogicException(sprintf('The "container.factory" tag on %s cannot declare an "expression" when the ExpressionLanguage component is not available.', $class->name));
+            }
+
+            return '@=' . $attributes['expression'];
+        }
+
+        $serviceReference = is_string($attributes['service'] ?? null) ? new Reference($attributes['service']) : null;
+
+        return [$attributes['class'] ?? $serviceReference, $attributes['method'] ?? '__invoke'];
+    }
+
+    // Option 2 : Rely on YamlFileLoader to register the factory like in RegisterAutoconfigureAttributesPass.
+    // Requires to add 'factory' and 'arguments' to the YamlFileLoader::INSTANCEOF_KEYWORDS const.
+    private function processDefinitionOption2(ContainerBuilder $container, Definition $definition, array $attributes): void
+    {
+        $class = $container->getReflectionClass($definition->getClass(), false);
+        if (null === $class) {
+            return;
+        }
+        // Prevent conflict with #[Autoconfigure(constructor: ...)]
+        $autoconfigureWithConstructor = array_filter(
+            $class->getAttributes(Autoconfigure::class, \ReflectionAttribute::IS_INSTANCEOF),
+            static fn(\ReflectionAttribute $attribute) => null !== $attribute->newInstance()->constructor
+        );
+        if (0 < \count($autoconfigureWithConstructor)) {
+            throw new AutoconfigureFailedException($class->name, sprintf('Using both attributes #[Factory] and #[Autoconfigure(constructor: ...)] on is not allowed in %s.', $class->getName()));
+        }
+
+        $factory = $this->resolveFactoryForOption2($attributes, $class);
+
+        if (isset(self::$registerForAutoconfiguration)) {
+            (self::$registerForAutoconfiguration)($container, $class, $factory, $attributes['arguments'] ?? []);
+
+            return;
+        }
+
+        $parseDefinitions = new \ReflectionMethod(YamlFileLoader::class, 'parseDefinitions');
+        $yamlLoader = $parseDefinitions->getDeclaringClass()->newInstanceWithoutConstructor();
+
+        self::$registerForAutoconfiguration = static function (ContainerBuilder $container, \ReflectionClass $class, array $factory, array $arguments) use ($parseDefinitions, $yamlLoader) {
+            $config = ['factory' => $factory, 'arguments' => $arguments];
+
+            $parseDefinitions->invoke(
+                $yamlLoader,
+                [
+                    'services' => [
+                        '_instanceof' => [
+                            $class->name => [$container->getDefinition($class->name)] + $config,
+                        ],
+                    ],
+                ],
+                $class->getFileName(),
+                false
+            );
+        };
+
+        (self::$registerForAutoconfiguration)($container, $class, $factory, $attributes['arguments'] ?? []);
+    }
+
+    private function resolveFactoryForOption2(array $attributes, \ReflectionClass $class): array|string
+    {
+        if (is_string($attributes['expression'] ?? null)) {
+            if (!class_exists(Expression::class)) {
+                throw new \LogicException(sprintf('The "container.factory" tag on %s cannot declare an "expression" when the ExpressionLanguage component is not available.', $class->name));
+            }
+
+            return '@=' . $attributes['expression'];
+        }
+
+        $method = $attributes['method'] ?? '__invoke';
+        $service = is_string($attributes['service'] ?? null) ? '@' . $attributes['service'] : null;
+
+        return [$attributes['class'] ?? $service, $method];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/FactoryTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/FactoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Attribute\Factory;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
+class FactoryTest extends TestCase
+{
+    public function testNoArguments()
+    {
+        new Factory();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testMethodOnly()
+    {
+        new Factory(method: 'my_method');
+        $this->assertEquals('my_method', (new Factory(method: 'my_method'))->method);
+    }
+
+    public function testClassAndService()
+    {
+        $this->expectException(LogicException::class);
+
+        new Factory(class: 'my_class', service: 'my_service');
+    }
+
+    public function testClassAndExpression()
+    {
+        $this->expectException(LogicException::class);
+
+        new Factory(class: 'my_class', expression: 'my_expression');
+    }
+
+    public function testServiceAndExpression()
+    {
+        $this->expectException(LogicException::class);
+
+        new Factory(service: 'my_service', expression: 'my_expression');
+    }
+
+    public function testClassAndServiceAndExpression()
+    {
+        $this->expectException(LogicException::class);
+
+        new Factory(class: 'my_class', service: 'my_service', expression: 'my_expression');
+    }
+
+    public function testExpressionAndMethod()
+    {
+        $this->expectException(LogicException::class);
+
+        new Factory(method: 'static_method', expression: 'my_expression');
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterFactoryPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterFactoryPassTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\RegisterFactoryPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @phpstan-type TagArguments array{class?: string, service?: string, method?: string, expression?: string, arguments?: array}
+ */
+class RegisterFactoryPassTest extends TestCase
+{
+    /**
+     * @dataProvider provideInvalid
+     *
+     * @param TagArguments             $tagArguments
+     * @param class-string<\Throwable> $exceptionClass
+     */
+    public function testInvalid(array $tagArguments, string $exceptionClass): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FactoryInstantiatedService::class)
+            ->setTags(['container.from_factory' => [$tagArguments]]);
+
+        $this->expectException($exceptionClass);
+
+        (new RegisterFactoryPass())->process($container);
+    }
+
+    /**
+     * @return list<array{0: TagArguments, 1: class-string<\Throwable>}>
+     */
+    public static function provideInvalid(): array
+    {
+        return [
+            // No method, no arguments
+            [[], LogicException::class],
+            [['class' => FactoryInstantiatedService::class, 'service' => 'service_id'], LogicException::class],
+            [['class' => FactoryInstantiatedService::class, 'expression' => 'expression'], LogicException::class],
+            [['service' => 'service_id', 'expression' => 'expression'], LogicException::class],
+            [['service' => 'service_id', 'class' => FactoryInstantiatedService::class], LogicException::class],
+            [['service' => 'service_id', 'class' => FactoryInstantiatedService::class, 'expression' => 'expression'], LogicException::class],
+            // No arguments
+            [['method' => 'create', 'expression' => 'expression'], LogicException::class],
+            [['method' => 'create', 'service' => 'service_id', 'expression' => 'expression'], LogicException::class],
+            [['method' => 'create', 'class' => FactoryInstantiatedService::class, 'expression' => 'expression'], LogicException::class],
+            [['method' => 'create', 'service' => 'service_id', 'class' => FactoryInstantiatedService::class], LogicException::class],
+            [['method' => 'create', 'service' => 'service_id', 'class' => FactoryInstantiatedService::class, 'expression' => 'expression'], LogicException::class],
+            // No method
+            [['arguments' => ['arg1', 'arg2'], 'service' => 'service_id', 'expression' => 'expression'], LogicException::class],
+            [['arguments' => ['arg1', 'arg2'], 'class' => FactoryInstantiatedService::class, 'expression' => 'expression'], LogicException::class],
+            [['arguments' => ['arg1', 'arg2'], 'service' => 'service_id', 'class' => FactoryInstantiatedService::class], LogicException::class],
+            [['arguments' => ['arg1', 'arg2'], 'service' => 'service_id', 'class' => FactoryInstantiatedService::class, 'expression' => 'expression'], LogicException::class],
+            // With methods and arguments
+            [['arguments' => ['arg1', 'arg2'], 'method' => 'create', 'service' => 'service_id', 'expression' => 'expression'], LogicException::class],
+            [['arguments' => ['arg1', 'arg2'], 'method' => 'create', 'class' => FactoryInstantiatedService::class, 'expression' => 'expression'], LogicException::class],
+            [['arguments' => ['arg1', 'arg2'], 'method' => 'create', 'service' => 'service_id', 'class' => FactoryInstantiatedService::class], LogicException::class],
+            [['arguments' => ['arg1', 'arg2'], 'method' => 'create', 'service' => 'service_id', 'class' => FactoryInstantiatedService::class, 'expression' => 'expression'], LogicException::class],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSelfFactory
+     *
+     * @param TagArguments                 $tagArguments
+     * @param array{string, string} $expectedFactory
+     */
+    public function testSelfFactory(array $tagArguments, array $expectedFactory, array $expectedArguments, string $instanceValidationKey): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FactoryInstantiatedService::class)
+            ->setPublic(true)
+            ->setTags(['container.from_factory' => [$tagArguments]]);
+
+        (new RegisterFactoryPass())->process($container);
+
+        $definition = $container->getDefinition('foo');
+        $this->assertEquals($expectedFactory, $definition->getFactory());
+        $this->assertEquals($expectedArguments, $definition->getArguments());
+        $container->compile();
+        $instance = $container->get('foo');
+        $this->assertEquals($instanceValidationKey, $instance->getInstanceValidationKey());
+    }
+
+    /**
+     * @return list<array{0: TagArguments, 1: array{string, string}, 2: array, 3: string}>
+     */
+    public static function provideSelfFactory(): array
+    {
+        return [
+            [['method' => 'create'], [FactoryInstantiatedService::class, 'create'], [], 'self_create'],
+            [['method' => 'create', 'class' => FactoryInstantiatedService::class], [FactoryInstantiatedService::class, 'create'], [], 'self_create'],
+            [['method' => 'create', 'class' => FactoryInstantiatedService::class, 'arguments' => [123456, '$foo' => 'bar']], [FactoryInstantiatedService::class, 'create'], [123456, '$foo' => 'bar'], 'self_create123456bar'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideServiceFactory
+     *
+     * @param TagArguments                 $tagArguments
+     * @param array{Reference, string} $expectedFactory
+     */
+    public function testServiceFactory(array $tagArguments, array $expectedFactory, array $expectedArguments, string $instanceValidationKey): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FactoryInstantiatedService::class)
+            ->setPublic(true)
+            ->setTags(['container.from_factory' => [$tagArguments]]);
+        $container->register('factory_service_id', FactoryInstantiatorService::class);
+        (new RegisterFactoryPass())->process($container);
+
+        $definition = $container->getDefinition('foo');
+        $this->assertEquals($expectedFactory, $definition->getFactory());
+        $this->assertEquals($expectedArguments, $definition->getArguments());
+        $container->compile();
+        $instance = $container->get('foo');
+        $this->assertEquals($instanceValidationKey, $instance->getInstanceValidationKey());
+    }
+
+    /**
+     * @return list<array{0: TagArguments, 1: array{Reference, string}, 2: array, 3: string}>
+     */
+    public static function provideServiceFactory(): array
+    {
+        return [
+            [['method' => 'create', 'service' => 'factory_service_id'], [new Reference('factory_service_id'), 'create'], [], 'service_create'],
+            [['method' => 'create', 'service' => '@factory_service_id', 'arguments' => ['arg1', '$foo' => 123456]], [new Reference('factory_service_id'), 'create'], ['arg1', '$foo' => 123456], 'service_createarg1123456'],
+            [['service' => 'factory_service_id', 'arguments' => ['arg1', '$foo' => 123456]], [new Reference('factory_service_id'), '__invoke'], ['arg1', '$foo' => 123456], 'service_invokearg1123456'],
+            [['service' => '@factory_service_id', 'arguments' => ['arg1', '$foo' => 123456]], [new Reference('factory_service_id'), '__invoke'], ['arg1', '$foo' => 123456], 'service_invokearg1123456'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideExpressionFactory
+     *
+     * @param TagArguments                 $tagArguments
+     * @param string $expectedFactory
+     */
+    public function testExpressionFactory(array $tagArguments, string $expectedFactory, array $expectedArguments, string $instanceValidationKey): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FactoryInstantiatedService::class)
+            ->setPublic(true)
+            ->setTags(['container.from_factory' => [$tagArguments]]);
+        $container->register('factory_service_id', FactoryInstantiatorService::class)
+            ->setPublic(true);
+        (new RegisterFactoryPass())->process($container);
+
+        $definition = $container->getDefinition('foo');
+        $this->assertEquals($expectedFactory, $definition->getFactory());
+        $this->assertEquals($expectedArguments, $definition->getArguments());
+        $container->compile();
+        $instance = $container->get('foo');
+        $this->assertEquals($instanceValidationKey, $instance->getInstanceValidationKey());
+    }
+
+    /**
+     * @return list<array{0: TagArguments, 1: string, 2: array, 3: string}>
+     */
+    public static function provideExpressionFactory(): array
+    {
+        return [
+            [
+                [
+                    'expression' => 'arg(0) + arg(1) > 10 ? service("factory_service_id").create(arg(0), arg(1)) : service("factory_service_id").__invoke(arg(0), arg(1))',
+                    'arguments' => [5, 9],
+                ],
+                '@=arg(0) + arg(1) > 10 ? service("factory_service_id").create(arg(0), arg(1)) : service("factory_service_id").__invoke(arg(0), arg(1))',
+                [5, 9],
+                'service_create59',
+            ],
+            [
+                [
+                    'expression' => '@=arg(0) + arg(1) > 10 ? service("factory_service_id").create(arg(0), arg(1)) : service("factory_service_id").__invoke(arg(0), arg(1))',
+                    'arguments' => [2, 4],
+                ],
+                '@=arg(0) + arg(1) > 10 ? service("factory_service_id").create(arg(0), arg(1)) : service("factory_service_id").__invoke(arg(0), arg(1))',
+                [2, 4],
+                'service_invoke24',
+            ],
+        ];
+    }
+}
+
+final class FactoryInstantiatedService
+{
+    public ?string $factoryName = null;
+    public array $args = [];
+
+    public static function create($randomArgName = null, $foo = null): self
+    {
+        $instance = new self();
+        $instance->factoryName = 'self_create';
+        $instance->args = [$randomArgName, $foo];
+
+        return $instance;
+    }
+
+    public function getInstanceValidationKey()
+    {
+        return $this->factoryName.implode('', $this->args);
+    }
+}
+
+final class FactoryInstantiatorService
+{
+    public function __invoke($randomArgName = null, $foo = null): FactoryInstantiatedService
+    {
+        return $this->createService('service_invoke', [$randomArgName, $foo]);
+    }
+
+    public function create($randomArgName = null, $foo = null): FactoryInstantiatedService
+    {
+        return $this->createService('service_create', [$randomArgName, $foo]);
+    }
+
+    private function createService($factoryName, $arguments)
+    {
+        $instance = new FactoryInstantiatedService();
+        $instance->factoryName = $factoryName;
+        $instance->args = $arguments;
+
+        return $instance;
+    }
+}


### PR DESCRIPTION
Add a `#[Factory]` attribute to define which factory to use directly from the class.

---
## Examples

Using another class' public static method
```php
#[Factory(class: App/MyStaticFactory::class, method: 'create', arguments: ['arg1', 'arg2'])]
class MyClass {
  // ...
}
```

Using its own public static method
```php
#[Factory(method: 'create', arguments: ['arg1', 'arg2'])]
class MyClass {
  public static function create($argument1, $argument2): self
  {
    //...
  }
}
```

Using a service
```php
#[Factory(service: App/MyFactory::class, method: 'create', arguments: [new TaggedIterator('custom_tag')]]
class MyClass {
  // ...
}
```

Using an expression
```php
#[Factory(expression: new Expression('...')]
class MyClass {
  // ...
}
```
I also thought it could be handy, when using the class itself as a factory, to be able apply the attribute directly on the method without specifying a class nor method
```php
class MyClass {
  #[Factory(arguments: [new TaggedIterator('custom_tag')]]
  public static function create(/*...*/)
  {
    // ...
  }
}
```

---

## Questions

Using the `YamlFileLoader` feels odd. Maybe extracting the `parseDefinition` (to a StringArrayLoader?) or `resolveServices` (to a RawStringConfigResolverTrait ?) from the `YamlFileLoader` would make sense.

Also I'm not sure if I should or how to test the autoconfiguration callback in FrameworkExtension.